### PR TITLE
Map to AWS WAF WACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,12 +209,12 @@ python ds-to-aws-waf.py iplists -u WAF -p PASSWORD -d DSM_HOSTNAME --ignore-ssl-
 The complete command syntax is;
 
 ```
-# ./ds-to-aws-waf.py sqli --help
 usage: ds-to-aws-waf.py sqli [-h] [-d DSM] [--dsm-port DSM_PORT] -u
                              DSM_USERNAME -p DSM_PASSWORD [-t DSM_TENANT]
                              [-r AWS_REGION] [--ignore-ssl-validation]
                              [--dryrun] [--verbose] [-l]
                              [--tag TAGS [TAGS ...]] [--create-match]
+                             [--map-to-wacl]
 
 Create and update AWS WAF WACL rules based on information from a Deep Security
 installation
@@ -253,6 +253,7 @@ optional arguments:
                         Specify the tags to filter the EC2 instances by
   --create-match        Create the SQLi match condition for use in various
                         rules
+  --map-to-wacl         Attempt to map each instance to an AWS WAF WACL
 ```
 
 <a name="ssl-certificate-validation" />

--- a/demo-placeholder.html
+++ b/demo-placeholder.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>AWS WAF Demo</title>
+  <style type="text/css">
+  body {
+    font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; 
+    font-size: 18pt;
+  }
+  h1 {
+    font-size: 2em;
+  }
+  div {
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 2em;
+    width: 50%;
+  }
+  </style>
+</head>
+
+<body>
+  <div>
+
+  <h1>AWS WAF Demo</h1>
+
+  <p>
+  This site is being served from an EC2 instance protected by AWS WAF.
+  </p>
+
+  </div>
+</body>
+
+</html>

--- a/lib/core.py
+++ b/lib/core.py
@@ -167,46 +167,30 @@ class ScriptContext():
 
     return dsm 
 
-  def _connect_to_aws_waf(self):
+  def _connect_to_aws_service(self, service_name):
     """
-    Connect to AWS WAF via explicit credentials (shared by the AWS CLI)
-    or an instance role
+    Connect to the specified AWS service via explicit credentials
+    (shared by the AWS CLI) or an instance role
     """
-    waf = None
+    service = None
     try:
       aws = boto3.session.Session(aws_access_key_id=self.aws_credentials['aws_access_key_id'], aws_secret_access_key=self.aws_credentials['aws_secret_access_key'])
-      waf = aws.client('waf') 
-      self._log("Connected to AWS WAF")
+      service = aws.client(service_name) 
+      self._log("Connected to AWS {}".format(service_name))
     except Exception, err: 
-      self._log("Could not connect to AWS WAF using local CLI credentials", err=err)
+      self._log("Could not connect to AWS {} using local CLI credentials".format(service_name), err=err)
       try:
-        waf = boto3.client('waf')
-        self._log("Connected to AWS WAF")
+        service = boto3.client(service_name)
+        self._log("Connected to AWS {}".format(service_name))
       except Exception, err:
-        self._log("Could not connect to AWS WAF using an instance role", err=err)  
+        self._log("Could not connect to AWS {} using an instance role".format(service_name), err=err)  
 
-    return waf
+    return service
 
-  def _connect_to_aws_ec2(self):
-    """
-    Connect to AWS EC2 via explicit credentials (shared by the AWS CLI)
-    or an instance role
-    """
-    ec2 = None
-    try:
-      aws = boto3.session.Session(aws_access_key_id=self.aws_credentials['aws_access_key_id'], aws_secret_access_key=self.aws_credentials['aws_secret_access_key'], region_name=self.args.aws_region)
-      ec2 = aws.client('ec2') 
-      self._log("Connected to AWS EC2")
-    except Exception, err: 
-      self._log("Could not connect to AWS EC2 using local CLI credentials", err=err)
-      try:
-        aws = boto3.session.Session(region_name=self.args.aws_region)
-        ec2 = aws.client('ec2') 
-        self._log("Connected to AWS EC2")
-      except Exception, err:
-        self._log("Could not connect to AWS EC2 using an instance role", err=err)  
-
-    return ec2    
+  def _connect_to_aws_waf(self): return self._connect_to_aws_service('waf')
+  def _connect_to_aws_ec2(self): return self._connect_to_aws_service('ec2')
+  def _connect_to_aws_elb(self): return self._connect_to_aws_service('elb')
+  def _connect_to_aws_cloudfront(self): return self._connect_to_aws_service('cloudfront')
 
   def get_available_aws_sets(self):
     """

--- a/lib/iplists.py
+++ b/lib/iplists.py
@@ -161,6 +161,7 @@ class Script(core.ScriptContext):
     addresses = []
     for address in ds_list.addresses:
       if "#" in address: address = address.split('#').strip() # remove any comments
+      if len(address.strip()) == 0: continue # skip empty lines
       if '-' in address:
         try:
           a1, a2 = address.split('-')

--- a/lib/sqli.py
+++ b/lib/sqli.py
@@ -49,6 +49,7 @@ def run_script(args):
     script.connect()
     script.get_waf_support_structures()
     script.map_instances_to_wacls()
+    script.print_instances_to_wacls_map()
 
   script.clean_up()
 
@@ -309,8 +310,20 @@ class Script(core.ScriptContext):
     self._log("   Instance\tRecommendation\tSuggested WACL", priority=True)
     for instance_id, recommendation in recommendations.items():
       suggested_wacl = self.instances_to_wacls[instance_id] if self.instances_to_wacls.has_key(instance_id) else ''
-      print "   {}\t{}\t{}".format(instance_id, recommendation, suggested_wacl, priority=True)
+      self._log("   {}\t{}\t{}".format(instance_id, recommendation, suggested_wacl), priority=True)
 
+    self._log("************************************************************************", priority=True)      
+
+  def print_instances_to_wacls_map(self):
+    """
+    Print the instances to WACLs map
+    """
+    self._log("************************************************************************", priority=True)
+    self._log("Discovered mappings of EC2 instance to WACL", priority=True)
+    self._log("   Instance\tSuggested WACL", priority=True)
+    for instance_id, instance in self.instances.items():
+      wacl = self.instances_to_wacls[instance_id] if self.instances_to_wacls.has_key(instance_id) else "---"
+      self._log("   {}\t{}".format(instance_id, wacl), priority=True)
     self._log("************************************************************************", priority=True)      
 
   def create_match_condition(self):


### PR DESCRIPTION
When asking Deep Security for a recommendation around SQLi protection, the tool now attempt to map the instance to a WACL. Currently supported is the most common: instance -> ELB -> CF distro -> WACL.

There is a command switch, `--map-to-wacl` to calculate and display the mappings. This process is automatic for the main recommendation
